### PR TITLE
chore: docker image arm64 명시적 빌드 제거

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           IMAGE_URI=$REGISTRY/$REPOSITORY:$IMAGE_TAG
-          # arm64 아키텍처로 빌드, AWS Lambda에서 비용이 저렴
-          docker build --platform linux/arm64 -t $IMAGE_URI .
+          docker build -t $IMAGE_URI .
           docker push $IMAGE_URI
           echo "image-uri=$IMAGE_URI" >> $GITHUB_OUTPUT
           


### PR DESCRIPTION
github actions 러너가 x86_64를 지원하는 걸로 확인되어 arm64 명시내용 제거